### PR TITLE
Use a single tab field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -1,40 +1,40 @@
 # Datatypes (KEYWORD1)
 
-LocoNetClass				KEYWORD1
-LocoNet						KEYWORD1
-LN_STATUS					KEYWORD1
-LnBuf						KEYWORD1
-LnBufStats
+LocoNetClass	KEYWORD1
+LocoNet	KEYWORD1
+LN_STATUS	KEYWORD1
+LnBuf	KEYWORD1
+LnBufStats	KEYWORD1
 
 
 # Methods and Functions (KEYWORD2)
 
-init						KEYWORD2
-receive						KEYWORD2
-send						KEYWORD2
+init	KEYWORD2
+receive	KEYWORD2
+send	KEYWORD2
 processSwitchSensorMessage	KEYWORD2
-requestSwitch				KEYWORD2
-reportSwitch				KEYWORD2
-notifySensor				KEYWORD2
-notifySwitchRequest			KEYWORD2
-notifySwitchReport			KEYWORD2
+requestSwitch	KEYWORD2
+reportSwitch	KEYWORD2
+notifySensor	KEYWORD2
+notifySwitchRequest	KEYWORD2
+notifySwitchReport	KEYWORD2
 notifySwitchOutputsReport	KEYWORD2
-notifySwitchState			KEYWORD2
+notifySwitchState	KEYWORD2
 
-initLnBuf					KEYWORD2
-recvLnMsg					KEYWORD2
-getLnBufStats				KEYWORD2
-getLnMsgSize				KEYWORD2
-addByteLnBuf				KEYWORD2
-addMsgLnBuf					KEYWORD2
-lnPacketReady				KEYWORD2
+initLnBuf	KEYWORD2
+recvLnMsg	KEYWORD2
+getLnBufStats	KEYWORD2
+getLnMsgSize	KEYWORD2
+addByteLnBuf	KEYWORD2
+addMsgLnBuf	KEYWORD2
+lnPacketReady	KEYWORD2
 
 # Constants (LITERAL1)
 
-LN_CD_BACKOFF				LITERAL1
-LN_PRIO_BACKOFF				LITERAL1
-LN_NETWORK_BUSY				LITERAL1
-LN_DONE						LITERAL1
-LN_COLLISION				LITERAL1
-LN_UNKNOWN_ERROR			LITERAL1
-LN_RETRY_ERROR				LITERAL1
+LN_CD_BACKOFF	LITERAL1
+LN_PRIO_BACKOFF	LITERAL1
+LN_NETWORK_BUSY	LITERAL1
+LN_DONE	LITERAL1
+LN_COLLISION	LITERAL1
+LN_UNKNOWN_ERROR	LITERAL1
+LN_RETRY_ERROR	LITERAL1


### PR DESCRIPTION
Each field of keywords.txt is separated by a single true tab. When you use multiple tabs it causes the field to be interpreted as empty. On Arduino IDE 1.6.5 and newer an empty KEYWORD_TOKENTYPE causes the default editor.function.style coloration to be used (as with KEYWORD2, KEYWORD3, LITERAL2). On Arduino IDE 1.6.4 and older it causes the keyword to not be recognized for any special coloration.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords