### PR TITLE
Made Arduino optional

### DIFF
--- a/LocoNet.cpp
+++ b/LocoNet.cpp
@@ -1762,7 +1762,7 @@ uint8_t LocoNetCVClass::processLNCVMessage(lnMsg * LnPacket) {
 	switch (LnPacket->sr.command) {
 	case OPC_IMM_PACKET:
 	case OPC_PEER_XFER:
-		DEBUG.println("Possibly a LNCV message.");
+		DEBUG("Possibly a LNCV message.");
 		// Either of these message types may be a LNCV message
 		// Sanity check: Message length, Verify addresses
 		if (LnPacket->ub.mesg_size == 15 && LnPacket->ub.DSTL == LNCV_MODULE_DSTL && LnPacket->ub.DSTH == LNCV_MODULE_DSTH) {

--- a/LocoNet.cpp
+++ b/LocoNet.cpp
@@ -1762,7 +1762,7 @@ uint8_t LocoNetCVClass::processLNCVMessage(lnMsg * LnPacket) {
 	switch (LnPacket->sr.command) {
 	case OPC_IMM_PACKET:
 	case OPC_PEER_XFER:
-		// Serial.println("Possibly a LNCV message.");
+		DEBUG.println("Possibly a LNCV message.");
 		// Either of these message types may be a LNCV message
 		// Sanity check: Message length, Verify addresses
 		if (LnPacket->ub.mesg_size == 15 && LnPacket->ub.DSTL == LNCV_MODULE_DSTL && LnPacket->ub.DSTH == LNCV_MODULE_DSTH) {
@@ -1837,7 +1837,9 @@ uint8_t LocoNetCVClass::processLNCVMessage(lnMsg * LnPacket) {
 								DEBUG(LnPacket->ub.payload.data.lncvValue);
 								DEBUG("\n");
 								makeLNCVresponse(response.ub, LnPacket->ub.SRC, LnPacket->ub.payload.data.deviceClass, 0x00, LnPacket->ub.payload.data.lncvValue, 0x80);
-								// delay(10); // for whatever reason, we need to delay, otherwise the message will not be sent.
+#if defined(ARDUINO)
+								delay(10); // for whatever reason, we need to delay, otherwise the message will not be sent.
+#endif
 								#ifdef DEBUG_OUTPUT
 								printPacket((lnMsg*)&response);
 								#endif

--- a/LocoNet.h
+++ b/LocoNet.h
@@ -69,7 +69,9 @@
 #if defined(ARDUINO) && ARDUINO >= 100
 #include "Arduino.h"
 #else
-#include "WProgram.h"
+#define byte uint8_t
+#define word uint16_t
+#include <inttypes.h>
 #endif
 
 #include "utility/ln_buf.h"
@@ -120,13 +122,18 @@ class LocoNetClass
 {
   private:
     LnBuf   LnBuffer ;
+#if defined(ARDUINO)
 	void 		setTxPin(uint8_t txPin);
-
+#endif
   public:
     LocoNetClass();
+#if defined(ARDUINO)
     void        init(void);
     void        init(uint8_t txPin);
-    boolean 		available(void);
+#else
+	void		init(volatile uint8_t *txPort, uint8_t txPin);
+#endif
+    bool		available(void);
     uint8_t			length(void);
     lnMsg*      receive(void);
     LN_STATUS   send(lnMsg *TxPacket);


### PR DESCRIPTION
Optionally removed the dependency on the arduino framework. Drops support for arduino versions lower then 1.0.0. If ARDUINO is defined the code is unchanged.
Besides putting all arduino code between `#if defined(ARDUINO)` a new constructor is added to specify the transmit pin.

Tested on an attiny84 running an S88 interface: [LNS88-firmware](https://git.krijnders.net/dirkjan/LNS88-firmware)