### PR TITLE
Make all methods of LocoNetSystemVariableClass public

### DIFF
--- a/LocoNet.h
+++ b/LocoNet.h
@@ -382,6 +382,7 @@ class LocoNetSystemVariableClass
   uint8_t DeferredProcessingRequired ;
   uint8_t DeferredSrcAddr ;
     
+  public:
 	/** Checks whether the given Offset is a valid value.
 	 *
 	 * Returns:
@@ -415,7 +416,6 @@ class LocoNetSystemVariableClass
 	 */
     bool CheckAddressRange(uint16_t startAddress, uint8_t Count);
 
-  public:
 	void init(uint8_t newMfgId, uint8_t newDevId, uint16_t newProductId, uint8_t newSwVersion);
 	
 	/**


### PR DESCRIPTION
Hi,

IMHO, there is no reason to make LocoNetSystemVariableClass methods isSVStorageValid(), readSVNodeId(), CheckAddressRange(), and writeSVNodeId() private. They should be all public ones.

The first 3 are all read-only and can be useful to use. writeSVNodeId is a high-level use of the already public writeSVStorage() and can be also quite useful.

Many thanks

Signed-off-by: Evili del Rio <evili.del.rio@gmail.com>