### PR TITLE
TX Echo Suppression & RX Byte Notification

### DIFF
--- a/LocoNet.h
+++ b/LocoNet.h
@@ -510,6 +510,11 @@ class LocoNetCVClass
 	extern "C" {
 #endif
 
+// Notify *from the ISR context* that a byte was received.
+// This is useful to, e.g., wake a task that will checks for new
+// LocoNet messages.
+extern void notifyLnByteReceived() __attribute__ ((weak));
+
 extern void notifySensor( uint16_t Address, uint8_t State ) __attribute__ ((weak));
 
 // Address: Switch Address.

--- a/LocoNet.h
+++ b/LocoNet.h
@@ -565,7 +565,7 @@ extern void notifySVChanged(uint16_t Offset) __attribute__ ((weak));
  * A response just as in the case of notifyLNCVProgrammingStart will be generated.
  * If a module responds to a LNCVDiscover, it should apparently enter programming mode immediately.
  */
-extern int8_t notifyLNCVdiscover( uint16_t & ArtNr, uint16_t & ModuleAddress ) __attribute__ ((weak));;
+extern int8_t notifyLNCVdiscover( uint16_t & ArtNr, uint16_t & ModuleAddress ) __attribute__ ((weak));
 
 /**
  * Notification that a LNCVProgrammingStart message was received. Application code should process this message and

--- a/utility/ln_config.h
+++ b/utility/ln_config.h
@@ -94,6 +94,12 @@ typedef volatile LnPortRegisterType* LnPortAddrType;
 // which is commonly used in DIY circuit designs, so its normal to be Inverted 
 #define LN_SW_UART_TX_INVERTED
 
+// Set LN_TX_ECHO to receive a copy of every transmitted message using LocoNet.receive()
+// Or set to 0 to suppress echos. Wrapped in #ifndef so it can be set on a per-build basis.
+#ifndef LN_TX_ECHO
+#define LN_TX_ECHO 1
+#endif
+
 #if defined(STM32F1)
 #define LN_BIT_PERIOD               (rcc_apb1_frequency * 2 / 16666)
 #else

--- a/utility/ln_config.h
+++ b/utility/ln_config.h
@@ -205,6 +205,11 @@ typedef volatile LnPortRegisterType* LnPortAddrType;
 #define LN_SB_SIGNAL          exti15_10_isr
 #define LN_TMR_SIGNAL         tim2_isr
 
+// Priority of the timer interrupt in hardware. If an OS is used and OS calls
+// are made from notifyLnByteReceived, this may have to be adjusted to match
+// the OS expectations. See the OS manual for details.
+#define LN_TMR_ISR_PRIO ((configMAX_SYSCALL_INTERRUPT_PRIORITY) + 64)
+
 // *****************************************************************************
 // *                                                       Arduino --UNKNOWN-- *
 // *****************************************************************************

--- a/utility/ln_sw_uart.cpp
+++ b/utility/ln_sw_uart.cpp
@@ -237,7 +237,9 @@ ISR(LN_TMR_SIGNAL)     /* signal handler for timer0 overflow */
       lnTxSuccess = 1 ;
 
       // Now copy the TX Packet into the RX Buffer
+#if (defined(LN_TX_ECHO) && (LN_TX_ECHO) != 0)
       addMsgLnBuf( lnRxBuffer, lnTxData );
+#endif
 
       // Begin CD Backoff state
       lnBitCount = 0 ;

--- a/utility/ln_sw_uart.cpp
+++ b/utility/ln_sw_uart.cpp
@@ -188,6 +188,9 @@ ISR(LN_TMR_SIGNAL)     /* signal handler for timer0 overflow */
     } 
     else { // Put the received byte in the buffer
       addByteLnBuf( lnRxBuffer, lnCurrentByte ) ;
+      if (notifyLnByteReceived != 0) {
+        notifyLnByteReceived();
+      }
     }
     lnBitCount = 0 ;
     lnState = LN_ST_CD_BACKOFF ;
@@ -239,6 +242,9 @@ ISR(LN_TMR_SIGNAL)     /* signal handler for timer0 overflow */
       // Now copy the TX Packet into the RX Buffer
 #if (defined(LN_TX_ECHO) && (LN_TX_ECHO) != 0)
       addMsgLnBuf( lnRxBuffer, lnTxData );
+      if (notifyLnByteReceived != 0) {
+        notifyLnByteReceived();
+      }
 #endif
 
       // Begin CD Backoff state
@@ -300,6 +306,7 @@ void initLocoNetHardware( LnBuf *RxBuffer )
 	rcc_periph_clock_enable(RCC_TIM2);
 
 	// Enable TIM2 interrupt.
+  nvic_set_priority(NVIC_TIM2_IRQ, LN_TMR_ISR_PRIO);
 	nvic_enable_irq(NVIC_TIM2_IRQ);
 
 	// Reset TIM2 peripheral to defaults.


### PR DESCRIPTION
This MR adds a notification when a single byte has been received from LocoNet. This is useful when running on an MCU with an operationg system, as the callback can be used to trigger tasks. When not interested in a notification, the callback can simply be ommited.

This MR also adds the option to suppress a TX message being fed back into the RX buffer. It does not affect the Collision Detection functionality while transmitting a LocoNet Message. The default setting restores the old behavior, where every TX message would show up in the RX buffer as well.