### PR TITLE
Add functions f9 f28

### DIFF
--- a/LocoNet.h
+++ b/LocoNet.h
@@ -133,6 +133,7 @@ public:
 	LN_STATUS   send(lnMsg* TxPacket);
 	LN_STATUS   send(lnMsg* TxPacket, uint8_t PrioDelay);
 	LN_STATUS   send(uint8_t OpCode, uint8_t Data1, uint8_t Data2);
+	LN_STATUS   send(uint8_t OpCode, uint8_t Data1, uint8_t Data2, uint8_t Data3, uint8_t Data4 );
 	LN_STATUS   send(uint8_t OpCode, uint8_t Data1, uint8_t Data2, uint8_t PrioDelay);
 	LN_STATUS   sendLongAck(uint8_t ucCode);
 
@@ -201,6 +202,10 @@ private:
 	uint8_t		   myStatus1;       // Stat1
 	uint8_t		   myDirFunc0to4;   // Direction
 	uint8_t		   myFunc5to8;       // Direction
+	uint8_t            myFunc9to11;
+	uint8_t            myFunc13to19 ; // without msb
+	uint8_t        myFunc12_20_28;
+	uint8_t            myFunc21to27 ;
 	uint8_t		   myUserData;
 	uint8_t		   myOptions;
 	uint32_t 	   myLastTimerMillis;
@@ -212,6 +217,11 @@ private:
 	void updateStatus1(uint8_t Status, uint8_t ForceNotify);
 	void updateDirectionAndFunctions(uint8_t DirFunc0to4, uint8_t ForceNotify);
 	void updateFunctions5to8(uint8_t Func5to8, uint8_t ForceNotify);
+	void updateFunctions9to11(uint8_t func9to11, uint8_t ForceNotify );
+	void updateFunctions13to19(uint8_t func13to19, uint8_t ForceNotify );
+	void updateFunction12_20_28(uint8_t func12_20_28, uint8_t ForceNotify );
+	void updateFunctions21to27(uint8_t Func21to27, uint8_t ForceNotify );
+	void updateFunctions9to12_Digikeijs(uint8_t func9to12, uint8_t ForceNotify ); // uses OPC_DIGIKEIJS_FUN
 	void updateSpeedSteps(TH_SPEED_STEPS SpeedSteps, uint8_t ForceNotify);
 
 public:
@@ -243,6 +253,8 @@ public:
 	TH_ERROR setFunction(uint8_t Function, uint8_t Value);
 	TH_ERROR setDirFunc0to4Direct(uint8_t Value);
 	TH_ERROR setFunc5to8Direct(uint8_t Value);
+	TH_ERROR setFunction9to28(uint8_t Function, uint8_t Value) ;
+	TH_ERROR resetAllFunctions() ;
 
 	TH_SPEED_STEPS getSpeedSteps(void);
 	void setSpeedSteps(TH_SPEED_STEPS newSpeedSteps);

--- a/test/test_functions/test_functions.ino
+++ b/test/test_functions/test_functions.ino
@@ -1,0 +1,139 @@
+/*****************************************************************************
+
+ Title :   LocoNet Throttle F9-F28 tester
+ Author:   Enrico Mattioli <@>
+ Date:     5-Sep-2021
+ Target:   ATMega328 Arduino
+
+ DESCRIPTION
+  This project is intended to check the correct woking of the F9-F28 function support.
+  The function will first enable functions F1-F28, one after another with a pause of DELAY_MILLIS.
+  Then all functions will be disabled in reverse order.
+  When done, all functions will be reset using LocoNetThrottleClass::resetAllFunctions().
+  Loco addr is LOCO_ADDR.
+  You may also set functions using an external throttle and check if the changes are correctly register (see Serial Terminal)
+
+*****************************************************************************/
+
+
+#include <LocoNet.h>
+
+uint16_t          LocoAddr ;
+
+LocoNetThrottleClass  Throttle;
+lnMsg                 *RxPacket ;
+uint32_t              LastThrottleTimerTick;
+
+#define LOCO_ADDR 3
+#define DELAY_MILLIS 1000
+
+boolean isTime(unsigned long *timeMark, unsigned long timeInterval)
+{
+    unsigned long timeNow = millis();
+    if ( timeNow - *timeMark >= timeInterval) {
+        *timeMark = timeNow;
+        return true;
+    }    
+    return false;
+}
+
+void setup()
+{
+  // First initialize the LocoNet interface
+  LocoNet.init(7);
+
+  // Configure the serial port for 57600 baud
+  Serial.begin(115200);
+
+  // throttle
+  Throttle.init(0, 0, 0);
+  Throttle.stealAddress(LOCO_ADDR);
+  Throttle.setAddress(LOCO_ADDR);
+  Throttle.acquireAddress();
+}
+
+void loop()
+{  
+  // Check for any received LocoNet packets
+  RxPacket = LocoNet.receive() ;
+
+  // process packets
+  if( RxPacket )
+  {
+    digitalWrite(13, LOW);
+    
+    if( !LocoNet.processSwitchSensorMessage(RxPacket) )
+      Throttle.processMessage(RxPacket) ;
+  }
+
+  // 100ms updates
+  if(isTime(&LastThrottleTimerTick, 100))
+  {
+    Throttle.process100msActions() ;
+    digitalWrite(13, HIGH);
+  }
+
+  function_set_unset();
+}
+
+void function_set_unset()
+{
+  static byte fn=0;
+  static bool count_up = true;
+  static unsigned long nextMillis=0;
+
+  if(millis()>nextMillis)
+  {
+      if (fn==0)
+      {
+          Throttle.resetAllFunctions();
+          count_up = true;
+      }
+      else if (fn>28)
+      {
+          count_up = false;
+      }
+      else
+      {
+          Throttle.setFunction(fn, count_up?1:0);
+      }
+
+      fn += count_up?1:-1;
+      
+      nextMillis=millis()+DELAY_MILLIS;
+  }
+}
+
+// Throttle notify Call-back functions
+void notifyThrottleAddress( uint8_t UserData, TH_STATE State, uint16_t Address, uint8_t Slot )
+{
+  Serial.print("Address: ");Serial.println(Address, DEC);
+}
+void notifyThrottleSpeed( uint8_t UserData, TH_STATE State, uint8_t Speed )
+{
+  Serial.print("Speed: ");Serial.println(Speed, DEC);
+}
+void notifyThrottleDirection( uint8_t UserData, TH_STATE State, uint8_t Direction )
+{
+  Serial.print("Direction: ");Serial.println(Direction, DEC);
+}
+void notifyThrottleFunction( uint8_t UserData, uint8_t Function, uint8_t Value )
+{
+  Serial.print("Function: ");Serial.print(Function, DEC);Serial.print(" = ");Serial.println(Value, DEC);
+}
+void notifyThrottleSlotStatus( uint8_t UserData, uint8_t Status )
+{
+  Serial.print("Throttle slot status: ");Serial.println(Status, DEC);
+}
+void notifyThrottleSpeedSteps( uint8_t UserData, TH_SPEED_STEPS SpeedSteps )
+{
+  Serial.print("Speed steps: ");Serial.println(Throttle.getSpeedStepStr(SpeedSteps));
+}
+void notifyThrottleError( uint8_t UserData, TH_ERROR Error )
+{
+  Serial.print("Throttle error: ");Serial.println(Throttle.getErrorStr(Error));
+}
+void notifyThrottleState( uint8_t UserData, TH_STATE PrevState, TH_STATE State )
+{
+  Serial.print("Throttle state: ");Serial.println(Throttle.getStateStr(State));
+}

--- a/utility/ln_opc.h
+++ b/utility/ln_opc.h
@@ -689,6 +689,17 @@ extern "C" {
 #define OPC_WR_SL_DATA    0xef
 #define OPC_MASK          0x7f  /* mask for acknowledge opcodes */
 
+/* functions F9 to F28 */
+/* opcodes */
+/* https://wiki.rocrail.net/doku.php?id=loconet:lnpe-parms-en */
+#define OPC_UHLI_FUN      0xD4
+#define OPC_DIGIKEIJS_FUN 0xA3
+/* arg3 */
+#define ARG3_FUN_9to11 0x07
+#define ARG3_FUN_12_20_28 0x05
+#define ARG3_FUN_13to19 0x08
+#define ARG3_FUN_21to27 0x09
+
 #if defined (__cplusplus)
 }
 #endif


### PR DESCRIPTION
Dear mrrwa team,

I would like to add support for functions F9-F28, currently not supported at all.

I implemented support for functions F9-F28 using Uhlenbrock opcode (OPC_UHLI_FUN) as described here: 
https://wiki.rocrail.net/doku.php?id=loconet:lnpe-parms-en

Also added support for reading some Digikeijs (DR5000 command station) function messages (OPC_DIGIKEIJS_FUN).

Summary:

 - Added support for F9-F28 using OPC_UHLI_FUN (receive and transmit)
 - Added support for F9-F12 (receive only) using OPC_DIGIKEIJS_FUN
 - Tested using Digikeijs DR5000 command station
 - Added a function LocoNetThrottleClass::resetAllFunctions to provide a quick way to reset a loco's functions.

Validation:
 - I have already evaluated correct operations using Digikeijs DR5000 command station.
 - Please find a test sketch in test/test_functions/test_functions.ino

Last but not least, I would like to give you my compliments on your LocoNet library. Used it to do some layout/staging yard automation (work in progress) and it works great.

Best regards,
Enrico