### PR TITLE
Fix for lost messages from Uhlenbrock Daisy II

### DIFF
--- a/utility/ln_sw_uart.cpp
+++ b/utility/ln_sw_uart.cpp
@@ -73,6 +73,8 @@ volatile uint8_t  lnBitCount;
 volatile uint8_t  lnCurrentByte;
 volatile LnCompareTargetType lnCompareTarget;
 
+bool checkStartBit = false;
+
 LnBuf* lnRxBuffer;
 volatile lnMsg* volatile lnTxData;
 volatile uint8_t  lnTxIndex;
@@ -191,9 +193,10 @@ ISR(LN_SB_SIGNAL)
 
 	// Reset the bit counter so that on first increment it is on 0
 	lnBitCount = 0;
-
-	// Next bit is startbit
+	
+	// Next Bit ist Startbit
 	checkStartBit=true;
+
 
 #if defined(ESP8266)
 	// Must clear this bit in the interrupt register,
@@ -239,13 +242,13 @@ ISR(LN_TMR_SIGNAL)     /* signal handler for timer0 overflow */
 		  lnState = LN_ST_CD_BACKOFF;
 #if defined(ESP8266)
 		   // Enable the pin interrupt
-#ifdef LN_SW_UART_RX_INVERTED
+#ifdef LN_SW_UART_RX_INVERTED  
 		   attachInterrupt(digitalPinToInterrupt(LN_RX_PORT), ln_esp8266_pin_isr, RISING);
 #else
 		   attachInterrupt(digitalPinToInterrupt(LN_RX_PORT), ln_esp8266_pin_isr, FALLING);
 #endif
 #else
-		   // Clear the Start Bit Interrupt Status Flag and Enable ready to
+		   // Clear the Start Bit Interrupt Status Flag and Enable ready to 
 		   // detect the next Start Bit
 		   LN_CLEAR_START_BIT_FLAG();
 		   LN_ENABLE_START_BIT_INTERRUPT();
@@ -253,7 +256,7 @@ ISR(LN_TMR_SIGNAL)     /* signal handler for timer0 overflow */
 		}
 		return;
 	}
-
+	
 	lnBitCount++;                // Increment bit_counter
 
 	if (lnState == LN_ST_RX) {  // Are we in RX mode

--- a/utility/ln_sw_uart.cpp
+++ b/utility/ln_sw_uart.cpp
@@ -238,7 +238,11 @@ ISR(LN_TMR_SIGNAL)     /* signal handler for timer0 overflow */
 	// Check if there is really a start bit or just a glitch
 	if (checkStartBit) {
 		checkStartBit = false;
+#ifdef LN_SW_UART_RX_INVERTED
+		if (bit_is_clear(LN_RX_PORT, LN_RX_BIT)) {
+#else
 		if (bit_is_set(LN_RX_PORT, LN_RX_BIT)) {
+#endif
 		  lnState = LN_ST_CD_BACKOFF;
 #if defined(ESP8266)
 		   // Enable the pin interrupt

--- a/utility/ln_sw_uart.h
+++ b/utility/ln_sw_uart.h
@@ -152,7 +152,8 @@
 
 // The Start Bit period is a full bit period + half of the next bit period
 // so that the bit is sampled in middle of the bit
-#define LN_TIMER_RX_START_PERIOD    LN_BIT_PERIOD + (LN_BIT_PERIOD / 2)
+//#define LN_TIMER_RX_START_PERIOD    LN_BIT_PERIOD + (LN_BIT_PERIOD / 2)
+#define LN_TIMER_RX_START_PERIOD    LN_BIT_PERIOD / 2 // Read Startbit to make sure we are not started by a glitch
 #define LN_TIMER_RX_RELOAD_PERIOD   LN_BIT_PERIOD 
 #define LN_TIMER_TX_RELOAD_PERIOD   LN_BIT_PERIOD 
 


### PR DESCRIPTION
Dear mrrwa-Team,

thanks for providing such a great software.

When using LocoNet with an Uhlenbrock Daisy II (actually a Piko Smart Control light in my case), I found that occasionally  messages form Daisy II got lost.

The logic analyzer showed that the Daisy II is sometimes generating short glitches on the Loconet data wire just before it sends a Loconet Message. The glitch is interpreted as a startbit, which causes the following message to get lost.

The glitches are much shorter than a bit, so reading and checking the value of the startbit solves the problem: If the data wire is high in the middle of the startbit, there was no startbit and we have to again wait for a real startbit. This makes the code more robust in general and might also help in case of other glitches on the data wire.

With this change, there were no missed messages any more.

I tested using the code of Philipp Gahtow (thanks to Philipp for his gerat work!)  on a Mega with two Loconet-Interfaces: Opamp-Version and simple resistor version. So there should not be any hardware related issues.

I also tested with Philipp's code for the ESP32, same problem and same solution.

I have no ESP8266, so no test here.

Best regards,
Peter