### PR TITLE
Remove unused anonymous extra argument on notifyLNCVread

### DIFF
--- a/LocoNet.cpp
+++ b/LocoNet.cpp
@@ -1841,7 +1841,7 @@ uint8_t LocoNetCVClass::processLNCVMessage(lnMsg* LnPacket) {
 					DEBUG("LNCV read: ");
 					if (notifyLNCVread) {
 						DEBUG(" executing...");
-						int8_t returnCode(notifyLNCVread(LnPacket->ub.payload.data.deviceClass, LnPacket->ub.payload.data.lncvNumber, LnPacket->ub.payload.data.lncvValue, LnPacket->ub.payload.data.lncvValue));
+						int8_t returnCode(notifyLNCVread(LnPacket->ub.payload.data.deviceClass, LnPacket->ub.payload.data.lncvNumber, LnPacket->ub.payload.data.lncvValue));
 						if (returnCode == LNCV_LACK_OK) {
 							// return the read value
 							makeLNCVresponse(response.ub, LnPacket->ub.SRC, LnPacket->ub.payload.data.deviceClass, LnPacket->ub.payload.data.lncvNumber, LnPacket->ub.payload.data.lncvValue, 0x00); // TODO: D7 was 0x80 here, but spec says that it is unused.

--- a/LocoNet.h
+++ b/LocoNet.h
@@ -590,7 +590,7 @@ extern "C" {
 	 * return code >= 0 leads to a NACK being sent.
 	 * return code < 0 will result in no reaction.
 	 */
-	extern int8_t notifyLNCVread(uint16_t ArtNr, uint16_t lncvAddress, uint16_t, uint16_t& lncvValue) __attribute__((weak));
+	extern int8_t notifyLNCVread(uint16_t ArtNr, uint16_t lncvAddress, uint16_t& lncvValue) __attribute__((weak));
 
 	/**
 	 * Notification that a LNCV value should be written. Application code should process this message and

--- a/examples/LocoNetLNCVDemo/LocoNetLNCVDemo.ino
+++ b/examples/LocoNetLNCVDemo/LocoNetLNCVDemo.ino
@@ -108,8 +108,7 @@ void dumpPacket(UhlenbrockMsg & ub) {
 	 * and "Programming Mode" state), it is not possible to distinguish
 	 * a read request from a programming start request message.
 	 */
-int8_t notifyLNCVread(uint16_t ArtNr, uint16_t lncvAddress, uint16_t,
-		uint16_t & lncvValue) {
+int8_t notifyLNCVread(uint16_t ArtNr, uint16_t lncvAddress, uint16_t & lncvValue) {
 	Serial.print("Enter notifyLNCVread(");
 	Serial.print(ArtNr, HEX);
 	Serial.print(", ");


### PR DESCRIPTION
Hello,

I think that there is an extra unneeded unused anonymous uint16_t argument in notifyLNCVread.

`extern int8_t notifyLNCVread(uint16_t ArtNr, uint16_t lncvAddress, uint16_t, uint16_t& lncvValue) __attribute__((weak));`

should be:

`extern int8_t notifyLNCVread(uint16_t ArtNr, uint16_t lncvAddress, uint16_t& lncvValue) __attribute__((weak));
`
I have made the corresponding changes on LocoNet.h, LocoNet.cpp, examples/LocoNetLNCVDemo/LocoNetLNCVDemo.ino
 in this fork.

Signed-off-by: Evili del Rio <evili@iiia.csic.es>
