### PR TITLE
Loconet Uart status

### DIFF
--- a/LocoNet.cpp
+++ b/LocoNet.cpp
@@ -172,6 +172,12 @@ bool LocoNetClass::available(void)
 	return lnPacketReady(&LnBuffer);
 }
 
+//Get the state of the uart, when value is 0, it is ok to send data; value list is ln_sw_uart.h
+LN_UART_STATE LocoNetClass::uartState()
+{
+	return uartLoconetState();
+}
+
 // Check the size in bytes of waiting message
 uint8_t LocoNetClass::length(void)
 {

--- a/LocoNet.h
+++ b/LocoNet.h
@@ -87,6 +87,16 @@ typedef enum
 	LN_RETRY_ERROR
 } LN_STATUS;
 
+typedef enum
+{
+	LN_ST_IDLE = 0, // net is free for anyone to start transmission
+	LN_ST_CD_BACKOFF = 1, // timer interrupt is counting backoff bits
+	LN_ST_TX_COLLISION = 2, // just sending break after creating a collision
+	LN_ST_TX = 3, // transmitting a packet
+	LN_ST_RX = 4 // receiving bytes
+} LN_UART_STATE;
+
+
 // CD Backoff starts after the Stop Bit (Bit 9) and has a minimum or 20 Bit Times
 // but initially starts with an additional 20 Bit Times 
 #define   LN_CARRIER_TICKS      20  // carrier detect backoff - all devices have to wait this
@@ -137,6 +147,7 @@ public:
 	LN_STATUS   send(uint8_t OpCode, uint8_t Data1, uint8_t Data2);
 	LN_STATUS   send(uint8_t OpCode, uint8_t Data1, uint8_t Data2, uint8_t PrioDelay);
 	LN_STATUS   sendLongAck(uint8_t ucCode);
+	LN_UART_STATE	uartState();
 
 	LnBufStats* getStats(void);
 

--- a/keywords.txt
+++ b/keywords.txt
@@ -3,6 +3,7 @@
 LocoNetClass	KEYWORD1
 LocoNet	KEYWORD1
 LN_STATUS	KEYWORD1
+LN_UART_STATE	KEYWORD1
 LnBuf	KEYWORD1
 LnBufStats	KEYWORD1
 
@@ -21,6 +22,7 @@ notifySwitchReport	KEYWORD2
 notifySwitchOutputsReport	KEYWORD2
 notifySwitchState	KEYWORD2
 notifyLongAck	KEYWORD2
+uartState	KEYWORD2
 
 initLnBuf	KEYWORD2
 recvLnMsg	KEYWORD2

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
   "name": "LocoNet",
-  "version": "1.1.13",
+  "version": "1.1.14",
   "keywords": "AVR, Railroad, LocoNet, ESP8266, STM32F1",
   "description": "Enables Digitrax LocoNet Communication. This library allows you to interface to a LocoNet network and send/receive LocoNet commands. The library currently supports the AVR ATTiny84 & ATMega88/168/328/32u4 using the 16-Bit Timer1 and ICP1. It also supports the Mega2560 using Timer5 and ICP5. It also supports the STM32F1 using TIM2 and the ESP8266 uses an hardware interrupt driven software uart.",
   "repository": {

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=LocoNet
-version=1.1.13
+version=1.1.14
 author=Alex Shepherd, John Plocher, Damian Philipp, Tom Knox, Hans Tanner, Björn Rennfanz
 maintainer=Alex Shepherd <kiwi64ajs@gmail.com>
 sentence=Enables Digitrax LocoNet Communication 

--- a/utility/ln_sw_uart.h
+++ b/utility/ln_sw_uart.h
@@ -141,11 +141,12 @@
 #  endif
 #endif
 
-#define LN_ST_IDLE            0   // net is free for anyone to start transmission
-#define LN_ST_CD_BACKOFF      1   // timer interrupt is counting backoff bits
-#define LN_ST_TX_COLLISION    2   // just sending break after creating a collision
-#define LN_ST_TX              3   // transmitting a packet
-#define LN_ST_RX              4   // receiving bytes
+//Moved to an ENUM inside of loconet.h, this to allow Uart LN status retrieval from the Loconet Class
+//#define LN_ST_IDLE            0   // net is free for anyone to start transmission
+//#define LN_ST_CD_BACKOFF      1   // timer interrupt is counting backoff bits
+//#define LN_ST_TX_COLLISION    2   // just sending break after creating a collision
+//#define LN_ST_TX              3   // transmitting a packet
+//#define LN_ST_RX              4   // receiving bytes
 
 #define LN_COLLISION_TICKS 15
 #define LN_TX_RETRIES_MAX  25
@@ -175,6 +176,7 @@
 // ATTENTION !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
 void initLocoNetHardware(LnBuf* RxBuffer);
+LN_UART_STATE uartLoconetState();
 void setTxPortAndPin(LnPortAddrType newTxPort, uint8_t newTxPin);
 LN_STATUS sendLocoNetPacketTry(lnMsg* TxData, unsigned char ucPrioDelay);
 #ifdef ESP8266


### PR DESCRIPTION
Adding ability to retrieve Loconet uart status, this to offer the able to control (hold) sending of packets if Loconet is busy.

```
LN_STATUS DoReportSensorState(uint16_t Address, uint8_t State)
{
  if (LocoNet.uartState() != LN_UART_STATE::LN_ST_IDLE)
  {
   //SPRNL(F("NOTREADY"));
   return LN_STATUS::LN_CD_BACKOFF;
  } else {
   LN_STATUS result = LocoNet.reportSensor(Address, State);
  }
}
```