### PR TITLE
Adds port for Arduino stm32 core.

### DIFF
--- a/LocoNet.cpp
+++ b/LocoNet.cpp
@@ -83,10 +83,10 @@ uint8_t eeprom_read_byte(const uint8_t* offset) {
 void eeprom_write_byte(const uint8_t* offset, uint8_t value) {
 	EEPROM.write((int)offset, value);
 }
-#elif defined(STM32F1)
-#  include <FreeRTOS.h>
-#  include <task.h>
-#  include <libopencm3/stm32/gpio.h>
+#elif defined(STM32F1) || defined(ARDUINO_ARCH_STM32)
+//#  include <FreeRTOS.h>
+//#  include <task.h>
+//#  include <libopencm3/stm32/gpio.h>
 #  include <cstdint>
 #else
 #  include <avr/eeprom.h>
@@ -154,7 +154,7 @@ void LocoNetClass::setTxPin(uint8_t txPin)
 	LnPortRegisterType bitMaskTest = 0x01;
 	LnPortRegisterType bitNum = 0;
 
-	LnPortRegisterType port = digitalPinToPort(txPin);
+	auto port = digitalPinToPort(txPin);
 	LnPortAddrType out = portOutputRegister(port);
 
 	while (bitMask != bitMaskTest)
@@ -618,7 +618,7 @@ void LocoNetThrottleClass::updateState(TH_STATE State, uint8_t ForceNotify)
 
 void LocoNetThrottleClass::updateStatus1(uint8_t Status, uint8_t ForceNotify)
 {
-	register uint8_t Mask;	// Temporary uint8_t Variable for bitwise AND to force
+	uint8_t Mask;	// Temporary uint8_t Variable for bitwise AND to force
 	// the compiler to only do 8 bit operations not 16
 
 	if (ForceNotify || myStatus1 != Status)
@@ -1428,7 +1428,7 @@ void LocoNetFastClockClass::process66msActions(void)
 	}
 }
 
-#if defined(STM32F1)
+#if defined(STM32F1) || defined(ARDUINO_ARCH_STM32)
 // STM31F1 has no EEPROM.
 #else
 
@@ -1760,7 +1760,7 @@ SV_STATUS LocoNetSystemVariableClass::doDeferredProcessing(void)
 	return SV_OK;
 }
 
-#endif // STM32F1
+#endif // STM32F1 || ARDUINO_ARCH_STM32
 
 
 /*****************************************************************************

--- a/LocoNet.cpp
+++ b/LocoNet.cpp
@@ -83,10 +83,12 @@ uint8_t eeprom_read_byte(const uint8_t* offset) {
 void eeprom_write_byte(const uint8_t* offset, uint8_t value) {
 	EEPROM.write((int)offset, value);
 }
-#elif defined(STM32F1) || defined(ARDUINO_ARCH_STM32)
-//#  include <FreeRTOS.h>
-//#  include <task.h>
-//#  include <libopencm3/stm32/gpio.h>
+#elif defined(STM32F1) 
+#  include <FreeRTOS.h>
+#  include <task.h>
+#  include <libopencm3/stm32/gpio.h>
+#  include <cstdint>
+#elif defined(ARDUINO_ARCH_STM32)
 #  include <cstdint>
 #else
 #  include <avr/eeprom.h>

--- a/LocoNet.h
+++ b/LocoNet.h
@@ -335,7 +335,7 @@ public:
 /************************************************************************************
 	SV (System Variable Handling
 ************************************************************************************/
-#if defined(STM32F1)
+#if defined(STM32F1) || defined(ARDUINO_ARCH_STM32)
 // STM31F1 has no flash.
 #else
 
@@ -490,7 +490,7 @@ public:
 	SV_STATUS doDeferredProcessing(void);
 };
 
-#endif // STM32F1
+#endif // STM32F1 || ARDUINO_ARCH_STM32
 
 class LocoNetCVClass
 {

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ It's known to work with:
 - MEGA (ATmega2560)
 - Leonardo, LeoStick, Arduino Pro Micro (ATmega32U4)
 - Various AVRTiny Boards (ATTiny84, ATTiny84A, ATTiny841)
-- Blue Pill (STM32F1 w/ libopencm3 and Arduino Stubs)
+- Blue Pill (STM32F1 w/ libopencm3 and Arduino Stubs, or STM32F3 with stm32duino core)
 - NodeMCU v1.0 (ESP8266 core for Arduino)
 
 As of 2020-03-28 - Hans Tanner added the capability to change the polarity

--- a/utility/ln_config.h
+++ b/utility/ln_config.h
@@ -55,7 +55,7 @@
  // figure out what board we are building
 
  // Common defines
-#if !defined(STM32F1) && !defined(ESP8266)
+#if !defined(STM32F1) && !defined(ARDUINO_ARCH_STM32) && !defined(ESP8266)
 #  ifdef PINL	//      For the Mega 2560 (should work with 1280, etc)
 #    define _LNET_USE_MEGA
 #  else		//	For the UNO:
@@ -72,7 +72,7 @@
 #  endif
 #endif
 
-#if defined(STM32F1)
+#if defined(STM32F1) || defined(ARDUINO_ARCH_STM32)
 typedef uint32_t LnPortRegisterType;
 typedef uint32_t LnCompareTargetType;
 #else
@@ -97,6 +97,8 @@ typedef volatile LnPortRegisterType* LnPortAddrType;
 #else
 #  if defined(STM32F1)
 #    define LN_BIT_PERIOD             (rcc_apb1_frequency * 2 / 16666)
+#  elif defined(ARDUINO_ARCH_STM32)
+#    define LN_BIT_PERIOD             (36000000 * 2 / 16666)
 #  else
 #    define LN_BIT_PERIOD             (F_CPU / 16666)
 #  endif
@@ -208,6 +210,22 @@ defined(__AVR_ATmega1284P__)
 #define LN_TMR_COUNT_REG      TCNT1     // and replaced their occurence in
 #define LN_TMR_CONTROL_REG    TCCR1B    // the code.
 #define LN_INIT_COMPARATOR() { TCCR1A = 0; TCCR1B = 0x01; }    // no prescaler, normal mode
+
+#elif defined(ARDUINO_ARCH_STM32)
+
+#define LN_RX_PIN_NAME PB14
+#define LN_RX_PORT  (*portInputRegister(GPIOB))
+#define LN_RX_BIT   (14)
+#define LN_RX_BITCFG LL_SYSCFG_EXTI_LINE14
+#define LN_RX_GPIOSEL EXTI_GPIOB
+#define LN_RX_GPIOCFG LL_SYSCFG_EXTI_PORTB
+
+
+#define LN_SB_SIGNAL          EXTI15_10_IRQHandler
+#define LN_SB_IRQn            EXTI15_10_IRQn
+#define LN_TMR_SIGNAL         TIM2_IRQHandler
+
+#define ISR(name) void name(void)
 
 #elif defined(STM32F1)
 

--- a/utility/ln_config.h
+++ b/utility/ln_config.h
@@ -98,8 +98,8 @@ typedef volatile LnPortRegisterType* LnPortAddrType;
 #  if defined(STM32F1)
 #    define LN_BIT_PERIOD             (rcc_apb1_frequency * 2 / 16666)
 #  elif defined(ARDUINO_ARCH_STM32)
+     // TMR2 runs at half the CPU clock on the STM32F3.
 #    define LN_BIT_PERIOD             (36000000 / 16666)
-//#    define LN_BIT_PERIOD             (72000000 * 2 / 16666)
 #  else
 #    define LN_BIT_PERIOD             (F_CPU / 16666)
 #  endif
@@ -213,6 +213,9 @@ defined(__AVR_ATmega1284P__)
 #define LN_INIT_COMPARATOR() { TCCR1A = 0; TCCR1B = 0x01; }    // no prescaler, normal mode
 
 #elif defined(ARDUINO_ARCH_STM32)
+// This architecture is used for the stm32 core in Arduino (aka stm32duino,
+// also present in the boards manager under 'stm32'. The default settings
+// are for an STM32F303RE (nucleo).
 
 #define LN_RX_PIN_NAME PB14
 #define LN_RX_PORT  (*portInputRegister(GPIOB))
@@ -220,11 +223,6 @@ defined(__AVR_ATmega1284P__)
 #define LN_RX_BITCFG LL_SYSCFG_EXTI_LINE14
 #define LN_RX_GPIOSEL EXTI_GPIOB
 #define LN_RX_GPIOCFG LL_SYSCFG_EXTI_PORTB
-
-
-#undef TIM2_IRQHandler
-#undef EXTI15_10_IRQHandler
-
 #define LN_SB_SIGNAL          EXTI15_10_IRQHandler
 #define LN_SB_IRQn            EXTI15_10_IRQn
 #define LN_TMR_SIGNAL         TIM2_IRQHandler

--- a/utility/ln_config.h
+++ b/utility/ln_config.h
@@ -98,7 +98,8 @@ typedef volatile LnPortRegisterType* LnPortAddrType;
 #  if defined(STM32F1)
 #    define LN_BIT_PERIOD             (rcc_apb1_frequency * 2 / 16666)
 #  elif defined(ARDUINO_ARCH_STM32)
-#    define LN_BIT_PERIOD             (36000000 * 2 / 16666)
+#    define LN_BIT_PERIOD             (36000000 / 16666)
+//#    define LN_BIT_PERIOD             (72000000 * 2 / 16666)
 #  else
 #    define LN_BIT_PERIOD             (F_CPU / 16666)
 #  endif
@@ -221,11 +222,14 @@ defined(__AVR_ATmega1284P__)
 #define LN_RX_GPIOCFG LL_SYSCFG_EXTI_PORTB
 
 
+#undef TIM2_IRQHandler
+#undef EXTI15_10_IRQHandler
+
 #define LN_SB_SIGNAL          EXTI15_10_IRQHandler
 #define LN_SB_IRQn            EXTI15_10_IRQn
 #define LN_TMR_SIGNAL         TIM2_IRQHandler
 
-#define ISR(name) void name(void)
+#define ISR(name) extern "C" void name(void)
 
 #elif defined(STM32F1)
 

--- a/utility/ln_sw_uart.cpp
+++ b/utility/ln_sw_uart.cpp
@@ -45,7 +45,7 @@
 extern "C" {
 #  include "gpio.h"
 }
-#elif defined(STM32F1)  // no ARCH here
+#elif defined(STM32F1)
 #  include <libopencm3/cm3/nvic.h>
 #  include <libopencm3/stm32/exti.h>
 #  include <libopencm3/stm32/gpio.h>
@@ -524,7 +524,6 @@ void initLocoNetHardware(LnBuf * RxBuffer)
 
 	// Enable TIM2 clock. 
         __HAL_RCC_TIM2_CLK_ENABLE();
-        //__HAL_RCC_EXTI_CLK_ENABLE();
 
 	// Enable TIM2 interrupt.
         NVIC_SetPriority(TIM2_IRQn, 0);
@@ -535,7 +534,7 @@ void initLocoNetHardware(LnBuf * RxBuffer)
         asm("nop ; nop ; nop; ");
         __HAL_RCC_TIM2_RELEASE_RESET();
 
-        /* Initializes the blinker timer. */
+        // Initializes TIM2 timer to count at max speed.
         TIM_HandleTypeDef TimHandle;
         memset(&TimHandle, 0, sizeof(TimHandle));
         TimHandle.Instance = TIM2;
@@ -549,8 +548,7 @@ void initLocoNetHardware(LnBuf * RxBuffer)
         // Disables all interrupts on the timer.
         TIM2->DIER = 0;
 
-  // Setup level change interrupt
-        
+        // Sets up level change interrupt on RX pin.
         LL_SYSCFG_SetEXTISource(LN_RX_GPIOCFG, LN_RX_BITCFG);
 #  ifdef LN_SW_UART_RX_INVERTED  
         LL_EXTI_EnableRisingTrig_0_31(LN_EXTI_FLAG);

--- a/utility/ln_sw_uart.cpp
+++ b/utility/ln_sw_uart.cpp
@@ -682,7 +682,7 @@ LN_STATUS sendLocoNetPacketTry(lnMsg * TxData, unsigned char ucPrioDelay)
 #  if defined(STM32F1) 
 	if (exti_get_flag_status(EXTI14)) {
 #  elif defined(ARDUINO_ARCH_STM32)
-	if (!LL_EXTI_IsActiveFlag_0_31(1u<<LN_RX_BIT)) {
+	if (LL_EXTI_IsActiveFlag_0_31(1u<<LN_RX_BIT)) {
 #  else
 	if (bit_is_set(LN_SB_INT_STATUS_REG, LN_SB_INT_STATUS_BIT)) {
 #  endif

--- a/utility/ln_sw_uart.h
+++ b/utility/ln_sw_uart.h
@@ -43,7 +43,7 @@
 
 #ifdef ESP8266
 #  include <Arduino.h>
-#elif !defined(STM32F1)
+#elif !defined(STM32F1) && !defined(ARDUINO_ARCH_STM32)
 #  include <avr/io.h>
 #  include <avr/interrupt.h>
 #endif
@@ -100,6 +100,25 @@
 #  define LN_ENABLE_TIMER_INTERRUPT() (timer_enable_irq(TIM2, TIM_DIER_CC1IE))
 // Disable Timer Compare Interrupt
 #  define LN_DISABLE_TIMER_INTERRUPT() (timer_disable_irq(TIM2, TIM_DIER_CC1IE))
+
+#elif defined(ARDUINO_ARCH_STM32)
+
+# define LN_EXTI_FLAG (1u << LN_RX_BIT)
+//Clear StartBit Interrupt flag
+#  define LN_CLEAR_START_BIT_FLAG() (LL_EXTI_ClearFlag_0_31(LN_EXTI_FLAG))
+//Enable StartBit Interrupt
+#  define LN_ENABLE_START_BIT_INTERRUPT() (LL_EXTI_EnableIT_0_31(LN_EXTI_FLAG))
+//Disable StartBit Interrupt
+#  define LN_DISABLE_START_BIT_INTERRUPT() (LL_EXTI_DisableIT_0_31(LN_EXTI_FLAG))
+
+// Clear Timer Interrupt Flag
+#  define LN_CLEAR_TIMER_FLAG() (LL_TIM_ClearFlag_CC1(TIM2))
+
+// Enable Timer Compare Interrupt
+#  define LN_ENABLE_TIMER_INTERRUPT() (LL_TIM_EnableIT_CC1(TIM2))
+// Disable Timer Compare Interrupt
+#  define LN_DISABLE_TIMER_INTERRUPT() (LL_TIM_DisableIT_CC1(TIM2))
+
 #elif !defined(ESP8266)
 //Clear StartBit Interrupt flag
 #  define LN_CLEAR_START_BIT_FLAG() (sbi( LN_SB_INT_STATUS_REG, LN_SB_INT_STATUS_BIT ))
@@ -116,6 +135,25 @@
 // Disable Timer Compare Interrupt
 #  define LN_DISABLE_TIMER_INTERRUPT() (cbi( LN_TMR_INT_ENABLE_REG, LN_TMR_INT_ENABLE_BIT ))
 #endif
+
+#if defined(ARDUINO_ARCH_STM32)
+#elif !defined(ESP8266)
+//Clear StartBit Interrupt flag
+#  define LN_CLEAR_START_BIT_FLAG() (sbi( LN_SB_INT_STATUS_REG, LN_SB_INT_STATUS_BIT ))
+//Enable StartBit Interrupt
+#  define LN_ENABLE_START_BIT_INTERRUPT() (sbi( LN_SB_INT_ENABLE_REG, LN_SB_INT_ENABLE_BIT ))
+//Disable StartBit Interrupt
+#  define LN_DISABLE_START_BIT_INTERRUPT() (cbi( LN_SB_INT_ENABLE_REG, LN_SB_INT_ENABLE_BIT ))
+
+// Clear Timer Interrupt Flag
+#  define LN_CLEAR_TIMER_FLAG() (sbi(LN_TMR_INT_STATUS_REG, LN_TMR_INT_STATUS_BIT))
+
+// Enable Timer Compare Interrupt
+#  define LN_ENABLE_TIMER_INTERRUPT() (sbi(LN_TMR_INT_ENABLE_REG, LN_TMR_INT_ENABLE_BIT))
+// Disable Timer Compare Interrupt
+#  define LN_DISABLE_TIMER_INTERRUPT() (cbi( LN_TMR_INT_ENABLE_REG, LN_TMR_INT_ENABLE_BIT ))
+#endif
+
 
 // For now we will simply check that TX and RX ARE NOT THE SAME as our circuit
 // requires the TX signal to be INVERTED.  If they are THE SAME then we have a 

--- a/utility/ln_sw_uart.h
+++ b/utility/ln_sw_uart.h
@@ -119,25 +119,9 @@
 // Disable Timer Compare Interrupt
 #  define LN_DISABLE_TIMER_INTERRUPT() (LL_TIM_DisableIT_CC1(TIM2))
 
-#elif !defined(ESP8266)
-//Clear StartBit Interrupt flag
-#  define LN_CLEAR_START_BIT_FLAG() (sbi( LN_SB_INT_STATUS_REG, LN_SB_INT_STATUS_BIT ))
-//Enable StartBit Interrupt
-#  define LN_ENABLE_START_BIT_INTERRUPT() (sbi( LN_SB_INT_ENABLE_REG, LN_SB_INT_ENABLE_BIT ))
-//Disable StartBit Interrupt
-#  define LN_DISABLE_START_BIT_INTERRUPT() (cbi( LN_SB_INT_ENABLE_REG, LN_SB_INT_ENABLE_BIT ))
-
-// Clear Timer Interrupt Flag
-#  define LN_CLEAR_TIMER_FLAG() (sbi(LN_TMR_INT_STATUS_REG, LN_TMR_INT_STATUS_BIT))
-
-// Enable Timer Compare Interrupt
-#  define LN_ENABLE_TIMER_INTERRUPT() (sbi(LN_TMR_INT_ENABLE_REG, LN_TMR_INT_ENABLE_BIT))
-// Disable Timer Compare Interrupt
-#  define LN_DISABLE_TIMER_INTERRUPT() (cbi( LN_TMR_INT_ENABLE_REG, LN_TMR_INT_ENABLE_BIT ))
-#endif
-
-#if defined(ARDUINO_ARCH_STM32)
-#elif !defined(ESP8266)
+#elif defined(ESP8266)
+// No common definitions needed for the ESP.
+#else // AVR
 //Clear StartBit Interrupt flag
 #  define LN_CLEAR_START_BIT_FLAG() (sbi( LN_SB_INT_STATUS_REG, LN_SB_INT_STATUS_BIT ))
 //Enable StartBit Interrupt


### PR DESCRIPTION
Creates a new port for the library to run on the stm32duino Arduino core. This is the "default" core available in the Arduino boards manager when the user searches for "stm32".
The port was built and tested on an STM32F303RE nucleo dev board. It uses the same resource layout as the previous stm32 port, i.e., input on PB14 and using the TMR2 timer resource. The input pin can be changed in ln_config.h (at compile time), but this was not tested. An arbitrary TX pin is supported (setting at run time).
Polarity selection of input and output is supported (at compile time).